### PR TITLE
修复高 DPI 面板越界、数据目录移至用户目录并补充拖拽/退出

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 1. **下载**：从 [Releases](https://github.com/rockswang/workbuddy-wild/releases) 下载最新版 `workbuddy-wild-windows-amd64.zip`，解压后双击 `workbuddy-wild.exe`
 2. 稍等片刻会弹出提示框，显示 **OpenAI 兼容 API 地址**（默认 `http://127.0.0.1:7863`）——记住它，关掉即可
-3. 右下角出现绿色 W 托盘图标，**单击 / 双击 / 右击** 都能打开管理面板
+3. 右下角出现绿色 W 托盘图标，**单击 / 双击** 直接打开管理面板，**右击**弹出托盘菜单（打开面板 / 退出）
 4. **添加账号**：面板点"＋ 添加账号"→ 选择 WorkBuddy 或 TraeWork → 自动打开无痕浏览器 → 登录对应平台 → 自动写入凭证并立即签到
 5. **配置客户端**：把你的 AI 客户端指向
    ```

--- a/frontend/dist/style.css
+++ b/frontend/dist/style.css
@@ -38,8 +38,14 @@ input, select, button { font: inherit; color: inherit; }
 .block { width: 100%; }
 .grow { flex: 1; min-width: 0; }
 
-/* 头部 */
-.header { display: flex; align-items: center; gap: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+/* 头部：设为 WebView2 无边框窗口的可拖拽区域（用户可按住拖走面板）；
+   内部可点击控件需显式声明 no-drag，否则无法响应点击。 */
+.header {
+  display: flex; align-items: center; gap: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--border);
+  -webkit-app-region: drag;
+  cursor: grab;
+}
+.header .icon-btn, .header input, .header select { -webkit-app-region: no-drag; }
 .logo {
   width: 24px; height: 24px; border-radius: 6px; flex: none;
   object-fit: contain; display: block;

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -288,21 +288,30 @@ func (a *App) OnShutdown(ctx context.Context) {
 	a.Close()
 }
 
-// panelRect 计算面板最终位置（贴主任务栏/工作区右下角，右、下留 12px 间隙）。
+// panelGap 面板与屏幕边缘（及任务栏）的间隙。
+const panelGap = 12
+
+// panelRect 计算面板最终位置（贴主任务栏/工作区右下角）。
 // 高度随账号数量自适应：0 账号基础高度 500，每 +1 账号增高 55（账号卡片实测约 55px），
 // 最多 4 个封顶（列表内部滚动）。退出按钮用 margin-top:auto 贴底，无需精确高度。
+//
+// 返回 (x, y) 为面板左上角<物理像素>坐标（喂给 WindowSetPosition，其原样加到物理工作区左上角），
+// (pw, ph) 为 DIP 尺寸（喂给 WindowSetSize，其内部按 DPI 放大回物理）。二者单位不同，
+// 若用同一批坐标喂给两个 API，在缩放显示屏上窗口物理尺寸会被放大而位置不变，导致右下角越界。
 func (a *App) panelRect() (x, y, pw, ph int) {
-	pw = 270
-	n := a.totalAccounts()
-	ph = 500 + minInt(n, 4)*55
-	_, _, waW, waH := winutil.WorkArea()
-	if int(waW) < pw {
-		pw = int(waW)
+	sc, logW, logH := a.dpiScale()
+	if sc <= 0 || logW <= 0 || logH <= 0 {
+		sc = 1 // 拿不到 DPI 时退化为 1:1，仍做屏幕内钳制
 	}
-	if int(waH) < ph {
-		ph = int(waH)
+	scrW, scrH := winutil.ScreenSize() // 原生物理像素
+	waX, waY, waW, waH := winutil.WorkArea()
+	tbX, tbY, tbW, tbH, ok := winutil.TaskbarRect()
+	if !ok {
+		tbX, tbY, tbW, tbH = 0, 0, 0, 0
 	}
-	x, y = winutil.PanelAnchor(pw, ph)
+	pw, ph = 270, 500+minInt(a.totalAccounts(), 4)*55
+	x, y, pw, ph = winutil.AnchorPanel(int(waX), int(waY), int(waW), int(waH),
+		int(tbX), int(tbY), int(tbW), int(tbH), sc, int(scrW), int(scrH), pw, ph, panelGap)
 	return x, y, pw, ph
 }
 
@@ -311,6 +320,38 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// dpiScale 返回 (DPI 缩放系数 sc, 主屏逻辑宽, 主屏逻辑高)。
+// sc = 物理像素 ÷ DIP = Screen.Width ÷ Screen.Size.Width：
+// wails 的 Screen.Width/Height 来自 EnumDisplayMonitors 的 RECT，是<物理像素>；
+// Screen.Size 经 ScaleToDefaultDPI 换算，才是逻辑 DIP。取二者比值恰好得到 DPI 系数
+// （125% 缩放下 sc=1.25），供 AnchorPanel 统一把 DIP 尺寸换算到物理坐标。
+func (a *App) dpiScale() (float64, int, int) {
+	if a.ctx == nil {
+		return 0, 0, 0
+	}
+	screens, err := runtime.ScreenGetAll(a.ctx)
+	if err != nil || len(screens) == 0 {
+		return 0, 0, 0
+	}
+	var s runtime.Screen
+	found := false
+	for _, sc := range screens {
+		if sc.IsPrimary {
+			s = sc
+			found = true
+			break
+		}
+	}
+	if !found && len(screens) > 0 {
+		s = screens[0]
+	}
+	if s.Width <= 0 || s.Size.Width <= 0 {
+		return 0, 0, 0
+	}
+	sc := float64(s.Width) / float64(s.Size.Width)
+	return sc, s.Size.Width, s.Size.Height
 }
 
 // positionPanel 把面板定位到右下角（贴任务栏），尺寸按账号数自适应。

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Version 面板展示的版本号。
-const Version = "0.2.2"
+const Version = "0.3.0"
 
 const (
 	loginTimeout   = 5 * time.Minute

--- a/internal/winutil/winutil.go
+++ b/internal/winutil/winutil.go
@@ -4,6 +4,7 @@ package winutil
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,11 +26,15 @@ var (
 	procSetForegroundWindow  = user32.NewProc("SetForegroundWindow")
 	procBringWindowToTop     = user32.NewProc("BringWindowToTop")
 	procGetWindowRect        = user32.NewProc("GetWindowRect")
+	procGetSystemMetrics     = user32.NewProc("GetSystemMetrics")
 )
 
 const (
 	spiGetWorkArea = 0x0030
 	wsExToolWindow = 0x00000080
+
+	smCXScreen = 0
+	smCYScreen = 1
 )
 
 // gwlExStyle GWL_EXSTYLE 索引；负数，需运行时转换，故用 var。
@@ -40,6 +45,110 @@ func WorkArea() (int32, int32, int32, int32) {
 	var rect struct{ Left, Top, Right, Bottom int32 }
 	procSystemParametersInfo.Call(uintptr(spiGetWorkArea), 0, uintptr(unsafe.Pointer(&rect)), 0)
 	return rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top
+}
+
+// ScreenSize 返回主显示器完整分辨率（含任务栏区域）的 (w, h)，单位与 WorkArea 一致。
+func ScreenSize() (int32, int32) {
+	w, _, _ := procGetSystemMetrics.Call(uintptr(smCXScreen))
+	h, _, _ := procGetSystemMetrics.Call(uintptr(smCYScreen))
+	return int32(w), int32(h)
+}
+
+// pixelRect 物理像素矩形。
+type pixelRect struct{ X, Y, W, H int }
+
+// AnchorPanel 计算面板到任务栏/工作区右下角的锚点位置，并做屏幕内钳制。
+//
+// 坐标系说明（重要）：Wails 在 Windows 上的窗口 API 使用两套不一致的坐标——
+//   - WindowSetSize 内部会按 DPI 把 DIP（逻辑像素）乘系数放大成物理像素；
+//   - WindowSetPosition 则是把传入值“原样”加到物理坐标的工作区左上角，绝不缩放。
+//
+// 因此本函数以原生物理像素为统一基准计算位置（左下角 0,0 对应屏幕左上角），
+// 面板目标尺寸按 DIP（sc）给出，返回面板左上角物理坐标 (x,y) 与 DIP 尺寸 (cwDip,chDip)，
+// 供调用方分别喂给 WindowSetPosition（物理）与 WindowSetSize（DIP）。
+//
+// 参数：wa*/tb* 为物理像素的原生工作区与任务栏矩形（tb 全 0 表示未探测到任务栏）；
+// sc 为 DPI 缩放系数（物理像素 = DIP × sc，如 125% 缩放时 sc=1.25）；scrW/scrH 为物理像素的
+// 主屏尺寸（用于钳制）；pwDip/phDip 为期望面板 DIP 尺寸；gapDip 为边距（DIP）。
+func AnchorPanel(waX, waY, waW, waH, tbX, tbY, tbW, tbH int, sc float64, scrW, scrH, pwDip, phDip, gapDip int) (x, y, cwDip, chDip int) {
+	if sc <= 0 || scrW <= 0 || scrH <= 0 {
+		sc = 1
+		if scrW <= 0 {
+			scrW = waW
+		}
+		if scrH <= 0 {
+			scrH = waH
+		}
+	}
+	round := func(v float64) int { return int(math.Round(v)) }
+
+	// DIP → 物理：尺寸与边距
+	pw := round(float64(pwDip) * sc)
+	ph := round(float64(phDip) * sc)
+	gap := round(float64(gapDip) * sc)
+
+	// 尺寸钳制（先不超过工作区，再不超过屏幕）
+	if pw > waW {
+		pw = waW
+	}
+	if ph > waH {
+		ph = waH
+	}
+	if pw > scrW {
+		pw = scrW
+	}
+	if ph > scrH {
+		ph = scrH
+	}
+
+	// 默认锚定：工作区右下角
+	x = waX + waW - pw - gap
+	y = waY + waH - ph - gap
+
+	if tbW > 0 && tbH > 0 {
+		if tbW > tbH {
+			// 水平任务栏（顶部/底部）
+			x = waX + waW - pw - gap
+			if tbY <= waY+waH/2 { // 顶部
+				y = tbY + tbH + gap
+			} else { // 底部
+				y = tbY - ph - gap
+			}
+		} else {
+			// 垂直任务栏（左侧/右侧）
+			y = waY + waH - ph - gap
+			if tbX <= waX+waW/2 { // 左侧
+				x = tbX + tbW + gap
+			} else { // 右侧
+				x = tbX - pw - gap
+			}
+		}
+	}
+
+	// 位置钳制进屏幕（物理）：绝不越出右下角
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	if scrW > 0 && x+pw > scrW-gap {
+		x = scrW - pw - gap
+	}
+	if scrH > 0 && y+ph > scrH-gap {
+		y = scrH - ph - gap
+	}
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	// 尺寸回 DIP，供 WindowSetSize（其内部会再放大 sc 倍回物理）
+	cwDip = round(float64(pw) / sc)
+	chDip = round(float64(ph) / sc)
+	return x, y, cwDip, chDip
 }
 
 // MainWindow 返回 wails 主窗口句柄（类名 wailsWindow）。
@@ -84,31 +193,8 @@ func InfoBox(title, msg string) {
 	InfoBoxEx(title, msg, 0x40 /* MB_ICONINFORMATION */)
 }
 
-// PanelAnchor 计算右下角弹出面板的位置：贴任务栏（避免被较宽/自动隐藏的任务栏遮挡），
-// 右、下各留 gap 间隙。任务栏探测失败时退回工作区右下角。
-func PanelAnchor(panelW, panelH int) (int, int) {
-	const gap = 12
-	waX, waY, waW, waH := WorkArea()
-	x, y, w, h := int(waX), int(waY), int(waW), int(waH)
-	if tbx, tby, tbw, tbh, ok := taskbarRect(); ok && tbw > 0 && tbh > 0 {
-		if int(tbw) > int(tbh) {
-			// 水平任务栏（顶部或底部）
-			if int(tby) <= y+h/2 { // 顶部
-				return x + w - panelW - gap, int(tby) + int(tbh) + gap
-			}
-			return x + w - panelW - gap, int(tby) - panelH - gap
-		}
-		// 垂直任务栏（左侧或右侧）
-		if int(tbx) <= x+w/2 { // 左侧
-			return int(tbx) + int(tbw) + gap, y + h - panelH - gap
-		}
-		return int(tbx) - panelW - gap, y + h - panelH - gap
-	}
-	return x + w - panelW - gap, y + h - panelH - gap
-}
-
-// taskbarRect 获取主任务栏（Shell_TrayWnd）屏幕矩形。
-func taskbarRect() (x, y, w, h int32, ok bool) {
+// TaskbarRect 获取主任务栏（Shell_TrayWnd）屏幕矩形（原生物理像素）。
+func TaskbarRect() (x, y, w, h int32, ok bool) {
 	cls, _ := syscall.UTF16PtrFromString("Shell_TrayWnd")
 	hwnd, _, _ := procFindWindowW.Call(uintptr(unsafe.Pointer(cls)), 0)
 	if hwnd == 0 {

--- a/internal/winutil/winutil_test.go
+++ b/internal/winutil/winutil_test.go
@@ -1,0 +1,92 @@
+package winutil
+
+import (
+	"math"
+	"testing"
+)
+
+// recons 由 AnchorPanel 返回的物理位置 + DIP 尺寸，重建出物理尺寸，便于与屏幕做越界断言。
+func physicalW(cwDip, chDip int, sc float64) (int, int) {
+	return int(math.Round(float64(cwDip) * sc)), int(math.Round(float64(chDip) * sc))
+}
+
+// TestAnchorPanel 锚点计算：返回的物理位置必须让重建后的物理窗口完整落在屏幕内（不越出右下角）。
+// 关键不变量：WindowSetPosition 收物理坐标、WindowSetSize 收 DIP（内部再放大 sc 回物理），
+// 两者必须一致到同一个物理矩形，否则贴右下的面板会在缩放显示屏上越界。
+func TestAnchorPanel(t *testing.T) {
+	type args struct {
+		waX, waY, waW, waH  int
+		tbX, tbY, tbW, tbH  int
+		sc                  float64
+		scrW, scrH          int
+		pwDip, phDip, gapDip int
+	}
+	tests := []struct {
+		name                          string
+		args                          args
+		wantX, wantY, wantWDip, wantHDip int
+	}{
+		{
+			// 125% 缩放（回归）：物理 1920x1080、底部任务栏 40。
+			// 修复前：窗口物理尺寸被 SetSize 放大 1.25 倍（270→338、500→625），
+			// 位置却按 270x500 算 → 右缘 1976>1920、底缘 1153>1080，整块越出右下角。
+			name: "底部任务栏、125% 缩放（回归：物理尺寸重建后必须完整在屏内）",
+			args: args{0, 0, 1920, 1040, 0, 1040, 1920, 40, 1.25, 1920, 1080, 270, 500, 12},
+			// 物理位置：x=1920-338-15=1567, y=1040-625-15=400；DIP 尺寸 270x500
+			wantX: 1567, wantY: 400, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			name: "底部任务栏、100% 缩放",
+			args: args{0, 0, 1920, 1040, 0, 1040, 1920, 40, 1, 1920, 1080, 270, 500, 12},
+			wantX: 1638, wantY: 528, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			name: "无任务栏、回退工作区右下角",
+			args: args{0, 0, 1920, 1080, 0, 0, 0, 0, 1, 1920, 1080, 270, 500, 12},
+			wantX: 1638, wantY: 568, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			name: "右侧垂直任务栏",
+			args: args{0, 0, 1860, 1080, 1860, 0, 60, 1080, 1, 1920, 1080, 270, 500, 12},
+			wantX: 1578, wantY: 568, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			name: "左侧垂直任务栏",
+			args: args{60, 0, 1860, 1080, 0, 0, 60, 1080, 1, 1920, 1080, 270, 500, 12},
+			wantX: 72, wantY: 568, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			name: "顶部任务栏",
+			args: args{0, 40, 1920, 1040, 0, 0, 1920, 40, 1, 1920, 1080, 270, 500, 12},
+			wantX: 1638, wantY: 52, wantWDip: 270, wantHDip: 500,
+		},
+		{
+			// 屏幕过小：面板 DIP 尺寸再放大 sc 后超过屏幕，必须钳制到屏幕内（退出按钮可达）。
+			name: "屏幕过小且高缩放：物理重建后必须落地且不越界",
+			args: args{0, 0, 900, 700, 0, 0, 0, 0, 1.25, 900, 700, 270, 900, 12},
+			// 物理 ph 被钳到 700、pw=338；位置 x=547,y=0；DIP = 270x560
+			wantX: 547, wantY: 0, wantWDip: 270, wantHDip: 560,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y, cw, ch := AnchorPanel(
+				tt.args.waX, tt.args.waY, tt.args.waW, tt.args.waH,
+				tt.args.tbX, tt.args.tbY, tt.args.tbW, tt.args.tbH,
+				tt.args.sc, tt.args.scrW, tt.args.scrH,
+				tt.args.pwDip, tt.args.phDip, tt.args.gapDip,
+			)
+			if x != tt.wantX || y != tt.wantY || cw != tt.wantWDip || ch != tt.wantHDip {
+				t.Errorf("AnchorPanel() = phys(%d,%d) dip(%dx%d), want phys(%d,%d) dip(%dx%d)",
+					x, y, cw, ch, tt.wantX, tt.wantY, tt.wantWDip, tt.wantHDip)
+			}
+			// 不变量：SetSize 用 DIP 放大 sc 后，物理矩形 (x,y,w,h) 必须完整在屏幕内。
+			pw, ph := physicalW(cw, ch, tt.args.sc)
+			if pw != 0 && ph != 0 {
+				if x < 0 || y < 0 || x+pw > tt.args.scrW || y+ph > tt.args.scrH {
+					t.Errorf("physical window (%d,%d,%d,%d) escapes screen (0,0,%d,%d)", x, y, pw, ph, tt.args.scrW, tt.args.scrH)
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,11 +38,21 @@ var assets embed.FS
 //go:embed build/trayicon.ico
 var trayIconICO []byte
 
+// dataRoot 程序数据根目录（用户主目录/.workbuddywild），main 启动时确定。
+var dataRoot string
+
 func main() {
-	// 工作目录固定为 exe 所在目录，保证相对路径配置（./auths ./data）稳定
-	if exe, err := os.Executable(); err == nil {
-		_ = os.Chdir(filepath.Dir(exe))
+	// 工作目录固定在用户主目录下 .workbuddywild：数据（config.json、auths、data）不随
+	// exe 位置变化，重装/升级/便携拷贝 exe 都不会丢数据。
+	home, homeErr := os.UserHomeDir()
+	switch {
+	case homeErr != nil || home == "":
+		dataRoot = "."
+	default:
+		dataRoot = filepath.Join(home, ".workbuddywild")
 	}
+	_ = os.MkdirAll(dataRoot, 0o755)
+	_ = os.Chdir(dataRoot)
 
 	cfgPath := "config.json"
 	cfg, err := config.Load(cfgPath)
@@ -151,23 +161,16 @@ func main() {
 	// 系统托盘：单击 / 双击 / 右击 均弹主面板（无原生右键菜单）
 	go runTray(appInst)
 
-	// WebView2 用户数据目录固定在 data/webview：不随 exe 改名变化，
+	// WebView2 用户数据目录固定在 dataRoot/data/webview：不随 exe 改名变化，
 	// 且启动前若有孤儿进程占用（强杀残留）先清理，避免白窗口长时间等待。
-	webviewPath := filepath.Join(filepath.Dir(mustExecutable()), "data", "webview")
+	webviewPath := filepath.Join(dataRoot, "data", "webview")
+	_ = os.MkdirAll(filepath.Dir(webviewPath), 0o755)
 	if winutil.IsWebViewProfileLocked(webviewPath) {
 		log.Printf("检测到孤儿 WebView2 进程占用 %s，正在清理", webviewPath)
 		winutil.KillOrphanWebViews(webviewPath)
 	}
 
 	runGUI(appInst, webviewPath)
-}
-
-// mustExecutable 返回当前 exe 的绝对路径（失败时退化为相对路径）。
-func mustExecutable() string {
-	if exe, err := os.Executable(); err == nil {
-		return exe
-	}
-	return os.Args[0]
 }
 
 // fatal 记录日志并弹出 MessageBox 后退出（GUI 无控制台，错误必须可见）。
@@ -219,14 +222,19 @@ func runGUI(a *app.App, webviewPath string) {
 	}
 }
 
-// runTray 托盘生命周期：无原生菜单，单击/双击/右击均弹主面板。
+// runTray 托盘生命周期：单击 / 双击直接弹主面板；右击弹出原生菜单（打开面板 / 退出）。
 // 回调全部 go 化：托盘消息循环线程只做投递，绝不执行重量级逻辑，避免托盘卡死。
 func runTray(a *app.App) {
 	systray.Run(func() {
 		systray.SetIcon(trayIconICO)
 		systray.SetTooltip("WorkBuddy-Wild — 托盘管理面板")
+		// 右击托盘图标弹出原生菜单；其中“退出”是面板异常/越界时也能退出的可靠通道。
+		mOpen := systray.AddMenuItem("打开管理面板", "显示 WorkBuddy-Wild 管理面板")
+		mQuit := systray.AddMenuItem("退出", "退出 WorkBuddy-Wild")
+		mOpen.Click(func() { go a.ShowPanel() })
+		mQuit.Click(func() { go a.QuitAll() })
 		systray.SetOnClick(func(systray.IMenu) { go a.ShowPanel() })
 		systray.SetOnDClick(func(systray.IMenu) { go a.ShowPanel() })
-		systray.SetOnRClick(func(systray.IMenu) { go a.ShowPanel() })
+		// 不设置 SetOnRClick：右击由 systray 显示上方原生菜单（含“退出”），保证退得出去
 	}, func() {})
 }

--- a/wails.json
+++ b/wails.json
@@ -10,7 +10,7 @@
   "info": {
     "companyName": "",
     "productName": "WorkBuddy Wild",
-    "productVersion": "0.2.2",
+    "productVersion": "0.3.0",
     "copyright": "",
     "comments": "WorkBuddy/CodeBuddy OpenAI 兼容代理 + 自动签到托盘工具"
   }


### PR DESCRIPTION
- AnchorPanel 统一以物理像素计算位置、DIP 计算尺寸，解决 125% 缩放下面板被 SetSize 放大后在右下角越界的问题，并做屏幕内钳制

- 无边框窗口头部增加 -webkit-app-region: drag 实现可拖拽

- 托盘右击菜单补充「打开面板 / 退出」，面板底部补退出按钮

- 数据根目录改为用户主目录下 .workbuddywild，随 exe 位置无关

- 新增 winutil_test.go 覆盖缩放/任务栏位置/小屏等锚点场景